### PR TITLE
Workflow cache

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -1,15 +1,20 @@
 name: Code Checks
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'  # Runs every Sunday at midnight to clear the cache
 
 jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
+      - uses: actions/checkout@v3
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+
   pycheck1ver:
     name: Python Lint/Format Checks
     runs-on: ubuntu-latest
@@ -19,29 +24,38 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r ./requirements.dev.txt
-    - name: Check with black
-      run: |
-        VERNUM=${{ matrix.python-version }}
-        TARGETV="py${VERNUM/./}"
-        python -m black -t $TARGETV --diff --color --check ./
-    - name: Check imports with isort (black)
-      run: |
-        python -m isort --profile=black --check --diff --color ./
-    - name: Check with flake8
-      run: |
-        python -m flake8 ./
-    - name: Check with Pylint
-      run: |
-        pylint --recursive=y .
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./requirements.dev.txt
+      - name: Check with black
+        run: |
+          VERNUM=${{ matrix.python-version }}
+          TARGETV="py${VERNUM/./}"
+          python -m black -t $TARGETV --diff --color --check ./
+      - name: Check imports with isort (black)
+        run: |
+          python -m isort --profile=black --check --diff --color ./
+      - name: Check with flake8
+        run: |
+          python -m flake8 ./
+      - name: Check with Pylint
+        run: |
+          pylint --recursive=y .
+
   pytyping:
     name: Python Type Checks
     runs-on: ubuntu-latest
@@ -49,17 +63,25 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        python-version: ["3.8", "3.9", "3.10","3.11","3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r ./requirements.dev.txt
-    - name: Check with MyPy on py${{ matrix.python-version }}
-      run: |
-        mypy --python-version ${{ matrix.python-version }} --warn-unused-ignores ./*.py
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ./requirements.dev.txt
+      - name: Check with MyPy on py${{ matrix.python-version }}
+        run: |
+          mypy --python-version ${{ matrix.python-version }} --warn-unused-ignores ./*.py

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -1,17 +1,13 @@
 name: Code Checks
 
-on:
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 0 * * 0'  # Runs every Sunday at midnight to clear the cache
+on: [push, pull_request]
 
 jobs:
   shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
 
@@ -24,23 +20,29 @@ jobs:
       matrix:
         python-version: ["3.10"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip dependencies for lint/format
-        uses: actions/cache@v3
+      - name: Load cached pip dependencies
+        uses: actions/cache/restore@v4
+        id: cache
         with:
           path: ~/.cache/pip
-          key: lint-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}
           restore-keys: |
-            lint-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
-            lint-${{ runner.os }}-pip-${{ matrix.python-version }}-
+            pip-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r ./requirements.dev.txt
+      - name: Save pip dependencies cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}
       - name: Check with black
         run: |
           VERNUM=${{ matrix.python-version }}
@@ -65,23 +67,29 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip dependencies for typing
-        uses: actions/cache@v3
+      - name: Load cached pip dependencies
+        uses: actions/cache/restore@v4
+        id: cache
         with:
           path: ~/.cache/pip
-          key: typing-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}
           restore-keys: |
-            typing-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
-            typing-${{ runner.os }}-pip-${{ matrix.python-version }}-
+            pip-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r ./requirements.dev.txt
+      - name: Save pip dependencies cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}
       - name: Check with MyPy on py${{ matrix.python-version }}
         run: |
           mypy --python-version ${{ matrix.python-version }} --warn-unused-ignores ./*.py

--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -29,14 +29,14 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip dependencies
+      - name: Cache pip dependencies for lint/format
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
+          key: lint-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            lint-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
+            lint-${{ runner.os }}-pip-${{ matrix.python-version }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -70,14 +70,14 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Cache pip dependencies
+      - name: Cache pip dependencies for typing
         uses: actions/cache@v3
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
+          key: typing-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            typing-${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('requirements.dev.txt') }}-
+            typing-${{ runner.os }}-pip-${{ matrix.python-version }}-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
After creating your pull request, tick these boxes if they are applicable to you.

- [x] I have tested my changes against the `fae` branch (the latest developmental version), and this pull request is targeting that branch as a base
- [x] I have tested my changes on Python 3.8 or higher
- [x] I have ensured my code is formatted using [Black](https://github.com/psf/black)

----

### Description
Adds improvements to run a faster workflow, and reduce overhead by caching the requirements. When a push or pull is done, and the workflow is triggered this should be able to grab a restore-key and use that. The cron job is set to run every Sunday at midnight, clearing the cache, and creating a new one to ensure packages are up to date. Each job and python version has a unique cache, by prefixing with: typing-Linux-pip-3.12 or lint-Linux-pip-3.10


### Related issues (if applicable)

